### PR TITLE
chore: restore sementic release

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ~/go/pkg/mod
-          key:          ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-${{ hashFiles('go.sum') }}
+          key:          ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-
 
       - name: Run benchmark
@@ -68,7 +68,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           path: ~/go/pkg/mod
-          key:          ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-${{ hashFiles('go.sum') }}
+          key:          ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-
 
       - name: Run benchmark (master)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      # Go
+      - "**"
+      - "!**.md"
+      - ".goreleaser"
+      - "go.*"
+      - "**.go"
+      # CI
+      - ".github/workflows/release.yml"
+
+jobs:
+  semantic-release:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    outputs:
+      new-release-published: ${{ steps.semantic-echo.outputs.new-release-published }}
+      release-version: ${{ steps.semantic-echo.outputs.release-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Run Semantic Release
+        id: semantic
+        uses: docker://ghcr.io/codfish/semantic-release-action:v1
+        with:
+          branches: |
+            ['master']
+          plugins: |
+            [
+              '@semantic-release/commit-analyzer',
+              '@semantic-release/release-notes-generator',
+              '@semantic-release/github'
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Export Semantic Release
+        id: semantic-echo
+        run: |
+          echo "::set-output name=new-release-published::${{steps.semantic.outputs.new-release-published}}"
+          echo "::set-output name=release-version::${{steps.semantic.outputs.release-version}}"
+
+  post-semantic-release:
+    needs: semantic-release
+    #if: needs.semantic-release.outputs.new-release-published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v1
+
+      - name: Setup go
+        run: |
+          asdf plugin add golang
+          asdf install golang
+
+      - name: Register version on pkg.go.dev
+        if: needs.semantic-release.outputs.new-release-published == 'true'
+        run: |
+          package=$(cat go.mod | grep ^module | awk '{print $2}')
+          version=v${{ needs.semantic-release.outputs.release-version }}
+          url=https://proxy.golang.org/${package}/@v/${version}.info
+          set -x +e
+          curl -i $url

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ~/go/pkg/mod
-          key:          ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-${{ hashFiles('go/**/go.sum') }}
+          key:          ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ env.go_version }}-${{ env.json_cache-versions_go }}-
 
       - name: Cache node modules


### PR DESCRIPTION
Enable Sementic Release to this repo in Github Action.

The `release.yml` file is from the Berty but I removed everything related to Gorealeaser because Wesnet there is not binary to compile.


<!-- Thank you for your contribution! ❤️ -->
