### PR TITLE
fix: activateGroupContext: wait for the watch new members goroutine to add the device key

### DIFF
--- a/group_context.go
+++ b/group_context.go
@@ -104,6 +104,9 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 	// syncChMKH := make(chan bool, 1)
 	// syncChSecrets := make(chan bool, 1)
 
+	wgFinished := sync.WaitGroup{}
+	wgFinished.Add(1)
+
 	{
 		// Fill keystore
 		chNewData := gc.FillMessageKeysHolderUsingNewData()
@@ -117,9 +120,16 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 
 		chMember := gc.WatchNewMembersAndSendSecrets()
 		go func() {
+			calledDone := false
 			for pk := range chMember {
 				if !pk.Equals(gc.memberDevice.PrivateMember().GetPublic()) {
 					gc.logger.Warn("gc member device public key doesn't match")
+					continue
+				}
+
+				if !calledDone {
+					calledDone = true
+					wgFinished.Done()
 				}
 			}
 		}()
@@ -159,7 +169,7 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 
 	if selfAnnouncement {
 		start := time.Now()
-		_, err := gc.MetadataStore().AddDeviceToGroup(gc.ctx)
+		op, err := gc.MetadataStore().AddDeviceToGroup(gc.ctx)
 		if err != nil {
 			return errcode.ErrInternal.Wrap(err)
 		}
@@ -167,16 +177,17 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 		gc.logger.Info(fmt.Sprintf("AddDeviceToGroup took %s", time.Since(start)))
 
 		// op.
-		// if op != nil {
-		// 	// Waiting for async events to be handled
-		// 	if ok := <-syncChMKH; !ok {
-		// 		return errcode.ErrInternal.Wrap(fmt.Errorf("error while registering own secrets"))
-		// 	}
+		if op != nil {
+			// Waiting for async events to be handled
+			wgFinished.Wait()
+			// 	if ok := <-syncChMKH; !ok {
+			// 		return errcode.ErrInternal.Wrap(fmt.Errorf("error while registering own secrets"))
+			// 	}
 
-		// 	if ok := <-syncChSecrets; !ok {
-		// 		return errcode.ErrInternal.Wrap(fmt.Errorf("error while sending own secrets"))
-		// 	}
-		// }
+			// 	if ok := <-syncChSecrets; !ok {
+			// 		return errcode.ErrInternal.Wrap(fmt.Errorf("error while sending own secrets"))
+			// 	}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
`activateGroupContext` calls `activateGroupContextactivateGroupContext` and starts a goroutine to monitor the channel for public keys of added devices. If `selfAnnouncement` is true, then `AddDeviceToGroup` is called so that the goroutine should receive the member's own device key. `activateGroupContext` can return before the asynchronous goroutines are signalled to add the device keys. Another function like `ActivateGroup` which calls `activateGroupContext` can return before all the needed keys are added. This is a bug because `ActivateGroup` does not finish activating the group because the needed keys are not added.

This pull request updates `activateGroupContext` to add a `WaitGroup` which is signalled by the `WatchNewMembersAndSendSecrets` goroutine. If `selfAnnouncement` is true and `AddDeviceToGroup` does not return nil (where nil means the device was already added) then wait for the `WaitGroup` to signal that the key was added. Now, when `activateGroupContext` returns, it means that the group context is fully activated.

This fix was tested on an Ubuntu 22.04 virtual machine (where the flappy tests fail more often then on macOS). This fix seems to make the following flappy tests pass:

    TestFlappyRestoreAccount
    TestRaceReactivateAccountGroup