### PR TITLE
fix: In Makefile asdf.install_plugins, remove spaces in error code check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ asdf.install_plugins:
 	@echo "Installing asdf plugins..."
 	@set -e; \
 	for PLUGIN in $$(cut -d' ' -f1 .tool-versions | grep "^[^\#]"); do \
-		asdf plugin add $$PLUGIN || [ $$? == 2 ] || exit 1; \
+		asdf plugin add $$PLUGIN || [ $$?==2 ] || exit 1; \
 	done
 .PHONY: asdf.install_plugins
 


### PR DESCRIPTION
The Makefile target `asdf.install_plugins` runs `asdf plugin add` and checks the error code. This works on macOS but not on Ubuntu which doesn't like the spaces around `==` . This pull request removes the spaces so that the check is `$$?==2` . Now it works on Ubuntu.