### PR TITLE
fix: Update gen.sum for changes in PR #18

### DIFF
--- a/gen.sum
+++ b/gen.sum
@@ -1,1 +1,1 @@
-50454b7c4b33a7ea1e12f93dc33c21fa55d86e95  Makefile
+fc3e83f6fb3e1767ff0b66940ca8d9ebe9f13372  Makefile


### PR DESCRIPTION
PR #18 changed the Makefile, but forgot to update `gen.sum`. This is the new output from 
`make regenerate` .