### PR TITLE
chore: In .github/ISSUE_TEMPLATE, update templates to be like go-orbit-db

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,38 +1,25 @@
+# yamllint disable-line rule:document-start
 name: "Bug report"
-description: Report a bug found while using the Berty apps or packages.
+description: Report a bug found while using weshnet.
 labels: ["bug", "🔍 Ready for Review"]
 assignees:
-- peletron
+  - jefft0
 body:
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
+      description: >-
+        Please search to see if an issue already exists for the bug you
+        encountered.
       options:
-      - label: I have searched the existing issues
-        required: true
-  - type: dropdown
-    id: product
-    attributes:
-      label: Berty product
-      description: What Berty product are you seeing the problem on?
-      options:
-        - Mobile app
-        - Desktop app
-        - CLI tools (berty mini, daemon, etc.)
-        - Code package
-    validations:
-      required: true
+        - label: I have searched the existing issues
+          required: true
   - type: input
-    id: product-version
+    id: package-version
     attributes:
-      label:  Berty product version
-      description: |+
-                  What is the version of this Berty product?
-
-                  Tip: You can find the version of the mobile and desktop apps in the settings.
-                  To display the CLI tool version, run `berty version`.
-      placeholder: e.g. 2.396.1
+      label: Package version
+      description: What version of weshnet are you using?
+      placeholder: v1.0.3
     validations:
       required: true
   - type: dropdown
@@ -47,39 +34,32 @@ body:
         - macOS
         - Windows
         - Other
+  - type: input
+    id: language-version
+    attributes:
+      label: Language version and compiler version
+      description: What programming language version and compiler are you using?
+      placeholder: >-
+        go1.18.4, javac 11.0.12
     validations:
       required: true
-  - type: input
-    id: version
-    attributes:
-      label: OS version
-      description: What is the version of the OS you are using?
-      placeholder: e.g. iOS 15.4 or Android 11.0 or Ubuntu 20.04.4
-    validations:
-      required: true
-  - type: input
-    id: device
-    attributes:
-      label: Device
-      description: What device are you using?
-      placeholder: e.g. iPhone 12 Pro Max or a Synology NAS
   - type: textarea
-    id: reproduction
+    id: bug-description
     attributes:
-      label: Steps to reproduce
-      description: Steps to reproduce the behavior.
+      label: Bug description
+      description: Provide a bug description and a code snippet if applicable.
       placeholder: |
-       1. Navigate to the ...
-       2. Click on the user ...
-       3. Change name of ...
-       4. Click Save button ...
+        1. Set up this environment ...
+        2. Add this code ...
+        3. Call this function ...
     validations:
       required: true
   - type: textarea
     id: current-behavior
     attributes:
       label: Current behavior
-      description: A description including screenshots, stack traces, debug logs, etc.
+      description: >-
+        Output after code execution including stack traces, debug logs, etc.
       placeholder: Currently ...
     validations:
       required: true
@@ -88,7 +68,17 @@ body:
     attributes:
       label: Expected behavior
       description: Please provide what would be your expectation to happen.
-      placeholder: In this situation, Berty should ...
+      placeholder: In this situation, weshnet should ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: What is your development environment?
+      placeholder: macOS 13.1
+    validations:
+      required: true
   - type: textarea
     id: other
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yml
@@ -1,3 +1,4 @@
+# yamllint disable-line rule:document-start
 name: "Feature request"
 description: Suggest an idea for this project.
 labels: [":rocket: feature-request", "🔍 Ready for Review"]
@@ -5,27 +6,19 @@ body:
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for this feature request.
+      description: >-
+        Please search to see if an issue already exists for this feature
+        request.
       options:
-      - label: I have searched the existing issues
-        required: true
-  - type: dropdown
-    id: product
-    attributes:
-      label: Berty product
-      description: What Berty product is the requsted feature for?
-      options:
-        - Mobile app
-        - Desktop app
-        - CLI tools (berty mini, daemon, etc.)
-        - Code package
-    validations:
-      required: true
+        - label: I have searched the existing issues
+          required: true
   - type: textarea
     id: feature
     attributes:
       label: Feature request
-      description: Provide a detailed description of the change or addition you are proposing.
+      description: >-
+        Provide a detailed description of the change or addition you are
+        proposing.
       placeholder: There should be ...
     validations:
       required: true
@@ -33,7 +26,9 @@ body:
     id: context
     attributes:
       label: Context
-      description: Why is this change important to you? How would you use it? How can it benefit other users?
+      description: >-
+        Why is this change important to you? How would you use it? How can it
+        benefit other users?
       placeholder: This feature request is important because ...
     validations:
       required: true
@@ -41,5 +36,6 @@ body:
     id: implementation
     attributes:
       label: Possible implementation
-      description: Not obligatory, but suggest an idea for implementing addition or change.
+      description: >-
+        Not obligatory, but suggest an idea for implementing addition or change.
       placeholder: This feature could be implemented by ...

--- a/.github/ISSUE_TEMPLATE/question_template.yml
+++ b/.github/ISSUE_TEMPLATE/question_template.yml
@@ -1,3 +1,4 @@
+# yamllint disable-line rule:document-start
 name: "Question"
 description: Ask a question about this project.
 labels: ["question", "🔍 Ready for Review"]
@@ -5,35 +6,28 @@ body:
   - type: checkboxes
     attributes:
       label: Asking a question, not reporting a bug
-      description: If your question is "Why did I get this error?" and you think it is a bug, then please open a Bug Report at https://github.com/berty/berty/issues/new/
+      description: >-
+        If your question is "Why did I get this error?" and you think it is a
+        bug, then please open a Bug Report at
+        https://github.com/berty/weshnet/issues/new/
       options:
-      - label: This question is not about a bug
-        required: true
+        - label: This question is not about a bug
+          required: true
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for your question.
+      description: >-
+        Please search to see if an issue already exists for your question.
       options:
-      - label: I have searched the existing issues
-        required: true
-  - type: dropdown
-    id: product
-    attributes:
-      label: Berty product
-      description: What Berty product is your question about?
-      options:
-        - Mobile app
-        - Desktop app
-        - CLI tools (berty mini, daemon, etc.)
-        - Code package
-        - General
-    validations:
-      required: true
+        - label: I have searched the existing issues
+          required: true
   - type: textarea
     id: question
     attributes:
       label: Question
-      description: Provide your question with enough detail that it is helpful to anyone reading the question (maybe years later).
+      description: >-
+        Provide your question with enough detail that it is helpful to anyone
+        reading the question (maybe years later).
       placeholder: How do I ...
     validations:
       required: true
@@ -41,7 +35,9 @@ body:
     id: context
     attributes:
       label: Context
-      description: Is it a general question about the design and goals of Berty, or about how to use the Berty app (or some other context)?
+      description: >-
+        Is it a general question about the design and goals of weshnet, or
+        about how to use use it in an app (or some other context)?
       placeholder: This is a question about ...
     validations:
       required: true


### PR DESCRIPTION
Update the GitHub issue templates to be [like go-orbit-db](https://github.com/berty/go-orbit-db/issues/new/choose). (This was done to make it appropriate for a developer package, not an end-user app.)