### PR TITLE
fix: Use result of atomic.AddInt64 in testGroupDeviceStatus, etc.

### DIFF
--- a/scenario_test.go
+++ b/scenario_test.go
@@ -148,10 +148,9 @@ func testGroupDeviceStatus(ctx context.Context, t *testing.T, groupID []byte, tp
 					statusReceivedLock.Unlock()
 
 					if done {
-						atomic.AddInt64(&nSuccess, 1)
-						nSuccess := atomic.LoadInt64(&nSuccess)
+						n := atomic.AddInt64(&nSuccess, 1)
 
-						got := fmt.Sprintf("%d/%d", nSuccess, ntps)
+						got := fmt.Sprintf("%d/%d", n, ntps)
 						tps[i].Opts.Logger.Debug("received all group device status", zap.String("ok", got))
 						return
 					}

--- a/testing.go
+++ b/testing.go
@@ -667,10 +667,9 @@ func CreateMultiMemberGroupInstance(ctx context.Context, t *testing.T, tps ...*T
 						secretsReceivedLock.Unlock()
 
 						if done {
-							atomic.AddInt64(&nSuccess, 1)
-							nSuccess := atomic.LoadInt64(&nSuccess)
+							n := atomic.AddInt64(&nSuccess, 1)
 
-							got := fmt.Sprintf("%d/%d", nSuccess, ntps)
+							got := fmt.Sprintf("%d/%d", n, ntps)
 							tps[i].Opts.Logger.Debug("received all secrets", zap.String("ok", got))
 							return
 						}


### PR DESCRIPTION
In `testGroupDeviceStatus` and `CreateMultiMemberGroupInstance`, the variable `nSuccess` is incremented by many goroutines to track the number of successes. To be thread-safe `nSuccess` is [incremented using atomic.AddInt64](https://github.com/berty/weshnet/blob/fddac566990798fc03b7409dc3a88856ab67df20/scenario_test.go#L151) . In the next line, `atomic.LoadInt64` is used to get the new value of `nSuccess`. The problem is that, between the calls to `AddInt64` and `LoadInt64`, another goroutine can increment the value. This is only used to print a log message in a test, and this is very unlikely to happen, so this bug has low severity. But it is code which may not do what was intended, and is confusing to read.

Fortunately, it is not necessary to call `LoadInt64` because `AddInt64` already returns the new value of `nSuccess` in a thread-safe way. This pull request updates to use the return value to print the log message.