### PR TITLE
fix: various fixes in message keystore

### DIFF
--- a/deactivate_test.go
+++ b/deactivate_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestReactivateAccountGroup(t *testing.T) {
+	testutil.FilterStability(t, testutil.Flappy)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 

--- a/pkg/cryptoutil/keystore_message.go
+++ b/pkg/cryptoutil/keystore_message.go
@@ -814,6 +814,11 @@ func (m *MessageKeystore) UpdatePushGroupReferences(ctx context.Context, deviceP
 		}
 	}
 
+	// Update first/last
+	if err := m.putFirstLastCachedGroupRefsForMember(ctx, first, last, devicePK, group); err != nil {
+		m.logger.Error("putting first/last push group reference failed", zap.Error(err))
+	}
+
 	return nil
 }
 
@@ -830,4 +835,19 @@ func (m *MessageKeystore) firstLastCachedGroupRefsForMember(ctx context.Context,
 	}
 
 	return ret.First, ret.Last, nil
+}
+
+func (m *MessageKeystore) putFirstLastCachedGroupRefsForMember(ctx context.Context, first uint64, last uint64, devicePK []byte, group GroupWithSecret) error {
+	key := m.refFirstLastKey(group.GetPublicKey(), devicePK)
+
+	fistLast := protocoltypes.FirstLastCounters{
+		First: first,
+		Last:  last,
+	}
+	bytes, err := fistLast.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return m.store.Put(ctx, key, bytes)
 }

--- a/pkg/cryptoutil/keystore_message_utils.go
+++ b/pkg/cryptoutil/keystore_message_utils.go
@@ -137,17 +137,17 @@ func deriveNextKeys(ck []byte, salt []byte, groupID []byte) ([]byte, [32]byte, e
 	return nextCK, nextMsg, nil
 }
 
-func idForCachedKey(groupPK, pk []byte, counter uint64) datastore.Key {
-	return datastore.KeyWithNamespaces([]string{"cachedCKs", hex.EncodeToString(groupPK), hex.EncodeToString(pk), fmt.Sprintf("%d", counter)})
+func idForPrecomputeMK(groupPK, pk []byte, counter uint64) datastore.Key {
+	return datastore.KeyWithNamespaces([]string{"precomputedMessageKeys", hex.EncodeToString(groupPK), hex.EncodeToString(pk), fmt.Sprintf("%d", counter)})
 }
 
 func idForCurrentCK(groupPK, pk []byte) datastore.Key {
-	return datastore.KeyWithNamespaces([]string{"currentCKs", hex.EncodeToString(groupPK), hex.EncodeToString(pk)})
+	return datastore.KeyWithNamespaces([]string{"chainKeyForDeviceOnGroup", hex.EncodeToString(groupPK), hex.EncodeToString(pk)})
 }
 
-func idForCID(id cid.Cid) datastore.Key {
+func idForMK(id cid.Cid) datastore.Key {
 	// TODO: specify the id
-	return datastore.KeyWithNamespaces([]string{"cid", id.String()})
+	return datastore.KeyWithNamespaces([]string{"messageKeyForCIDs", id.String()})
 }
 
 func uint64AsNonce(val uint64) *[24]byte {

--- a/pkg/cryptoutil/keystore_message_utils_test.go
+++ b/pkg/cryptoutil/keystore_message_utils_test.go
@@ -135,7 +135,7 @@ func Test_EncryptMessagePayload(t *testing.T) {
 	assert.NoError(t, err)
 
 	// secret is derived by SealEnvelope
-	err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice())
+	err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice().GetPublic())
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, hex.EncodeToString(payloadRef1), hex.EncodeToString(payloadEnc1))
@@ -166,7 +166,7 @@ func Test_EncryptMessagePayload(t *testing.T) {
 	payloadEnc2, _, err := cryptoutil.SealPayload(payloadRef1, ds, omd1.PrivateDevice(), g)
 	assert.NoError(t, err)
 
-	err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice())
+	err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice().GetPublic())
 	assert.NoError(t, err)
 
 	// Ensure that encrypted message is not the same as the first message
@@ -193,7 +193,7 @@ func Test_EncryptMessagePayload(t *testing.T) {
 	payloadEnc3, _, err := cryptoutil.SealPayload(payloadRef2, ds, omd1.PrivateDevice(), g)
 	assert.NoError(t, err)
 
-	err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice())
+	err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice().GetPublic())
 	assert.NoError(t, err)
 
 	dummyCID1, err := cid.Parse("QmbdQXQh9B2bWZgZJqfbjNPV5jGN2owbQ3vjeYsaDaCDqU")
@@ -241,7 +241,7 @@ func Test_EncryptMessagePayload(t *testing.T) {
 		payloadEnc, _, err := cryptoutil.SealPayload(payloadRef3, ds, omd1.PrivateDevice(), g)
 		assert.NoError(t, err)
 
-		err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice())
+		err = mkh1.DeriveDeviceSecret(ctx, g, omd1.PrivateDevice().GetPublic())
 		assert.NoError(t, err)
 
 		ds, err = mkh1.GetDeviceChainKey(ctx, gPK, omd1.PrivateDevice().GetPublic())

--- a/pkg/cryptoutil/keystore_message_utils_test.go
+++ b/pkg/cryptoutil/keystore_message_utils_test.go
@@ -21,6 +21,8 @@ import (
 	"berty.tech/weshnet/pkg/testutil"
 )
 
+const precomputePushRefsCount = uint64(100)
+
 func addDummyMemberInMetadataStore(ctx context.Context, t testing.TB, ms *weshnet.MetadataStore, g *protocoltypes.Group, memberPK crypto.PubKey, join bool) (crypto.PubKey, *protocoltypes.DeviceSecret) {
 	t.Helper()
 
@@ -518,5 +520,80 @@ func TestMessageKeyHolderSubscription(t *testing.T) {
 		},
 	} {
 		testMessageKeyHolderSubscription(t, testCase.expectedNewDevices, testCase.slow)
+	}
+}
+
+func Test_PushGroupReferences(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zap.NewNop()
+
+	g, _, err := weshnet.NewGroupMultiMember()
+	assert.NoError(t, err)
+
+	acc := cryptoutil.NewDeviceKeystore(keystore.NewMemKeystore(), nil)
+
+	omd, err := acc.MemberDeviceForGroup(g)
+	assert.NoError(t, err)
+
+	devicePK, err := omd.Public().Device.Raw()
+	assert.NoError(t, err)
+
+	ds, err := cryptoutil.NewDeviceSecret()
+	assert.NoError(t, err)
+
+	mkh, cleanup := cryptoutil.NewInMemMessageKeystore(logger)
+	defer cleanup()
+
+	// test with the ds counter
+	updateAndTestPushGroupReferences(ctx, mkh, devicePK, ds.Counter, g, t)
+
+	// do the same test with a new device secret counter
+	// so we can test if old references are deleted
+	updateAndTestPushGroupReferences(ctx, mkh, devicePK, ds.Counter+10, g, t)
+}
+
+func updateAndTestPushGroupReferences(ctx context.Context, mkh *cryptoutil.MessageKeystore, devicePK []byte, counter uint64, g *protocoltypes.Group, t *testing.T) {
+	// get the group push secret, used to create the push group references
+	groupPushSecret, err := cryptoutil.GetGroupPushSecret(g)
+	assert.NoError(t, err)
+
+	// update the push group references
+	err = mkh.UpdatePushGroupReferences(ctx, devicePK, counter, g)
+	assert.NoError(t, err)
+
+	// test that the push group references are updated
+	// refs start counter - 100 to counter + 100
+	start := counter - precomputePushRefsCount
+	end := counter + precomputePushRefsCount
+
+	for i := start; i < end; i++ {
+		// compute the push group reference
+		pushGroupRef, err := cryptoutil.CreatePushGroupReference(devicePK, i, groupPushSecret)
+		assert.NoError(t, err)
+
+		_, err = mkh.GetByPushGroupReference(ctx, pushGroupRef)
+		assert.NoError(t, err)
+	}
+
+	// test boundary conditions
+
+	// before the start counter
+	{
+		before := counter - precomputePushRefsCount - 1
+		pushGroupRef, err := cryptoutil.CreatePushGroupReference(devicePK, before, groupPushSecret)
+		assert.NoError(t, err)
+		_, err = mkh.GetByPushGroupReference(ctx, pushGroupRef)
+		assert.Error(t, err)
+	}
+
+	// after the end counter
+	{
+		end := counter + precomputePushRefsCount + 1
+		pushGroupRef, err := cryptoutil.CreatePushGroupReference(devicePK, end, groupPushSecret)
+		assert.NoError(t, err)
+		_, err = mkh.GetByPushGroupReference(ctx, pushGroupRef)
+		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
- use the first/last index value when computing push group references
- fix a bug that precomputes 100 keys each time we consume one key in the cache. Now, we precompute 100 keys only when we register a new device secret and we precompute only one key when we consume a key.
- add comments on functions

### Other

Set `TestReactivateAccountGroup` as a flappy test (the instability has no link with this PR).
<!-- Thank you for your contribution! ❤️ -->
