### PR TITLE
chore: Rename BertyOrbitDB to WeshOrbitDB

### DIFF
--- a/account_export.go
+++ b/account_export.go
@@ -380,7 +380,7 @@ func (state *restoreAccountState) readKey(keyName string) RestoreAccountHandler 
 	}
 }
 
-func (state *restoreAccountState) restoreKeys(odb *BertyOrbitDB) RestoreAccountHandler {
+func (state *restoreAccountState) restoreKeys(odb *WeshOrbitDB) RestoreAccountHandler {
 	return RestoreAccountHandler{
 		PostProcess: func() error {
 			if err := odb.deviceKeystore.RestoreAccountKeys(state.keys[exportAccountKeyFilename], state.keys[exportAccountProofKeyFilename]); err != nil {
@@ -415,7 +415,7 @@ func restoreOrbitDBEntry(ctx context.Context, coreAPI ipfs_interface.CoreAPI) Re
 	}
 }
 
-func restoreOrbitDBHeads(ctx context.Context, odb *BertyOrbitDB) RestoreAccountHandler {
+func restoreOrbitDBHeads(ctx context.Context, odb *WeshOrbitDB) RestoreAccountHandler {
 	return RestoreAccountHandler{
 		Handler: func(header *tar.Header, reader *tar.Reader) (bool, error) {
 			if !strings.HasPrefix(header.Name, exportOrbitDBHeadsPrefix) {
@@ -440,7 +440,7 @@ func restoreOrbitDBHeads(ctx context.Context, odb *BertyOrbitDB) RestoreAccountH
 	}
 }
 
-func RestoreAccountExport(ctx context.Context, reader io.Reader, coreAPI ipfs_interface.CoreAPI, odb *BertyOrbitDB, logger *zap.Logger, handlers ...RestoreAccountHandler) error {
+func RestoreAccountExport(ctx context.Context, reader io.Reader, coreAPI ipfs_interface.CoreAPI, odb *WeshOrbitDB, logger *zap.Logger, handlers ...RestoreAccountHandler) error {
 	tr := tar.NewReader(reader)
 	state := restoreAccountState{
 		keys: map[string]crypto.PrivKey{},

--- a/account_export_test.go
+++ b/account_export_test.go
@@ -224,7 +224,7 @@ func TestFlappyRestoreAccount(t *testing.T) {
 
 		dksB := cryptoutil.NewDeviceKeystore(ipfsutil.NewDatastoreKeystore(datastoreutil.NewNamespacedDatastore(dsB, ds.NewKey(NamespaceDeviceKeystore))), nil)
 
-		odb, err := NewBertyOrbitDB(ctx, ipfsNodeB.API(), &NewOrbitDBOptions{
+		odb, err := NewWeshOrbitDB(ctx, ipfsNodeB.API(), &NewOrbitDBOptions{
 			NewOrbitDBOptions: orbitdb.NewOrbitDBOptions{
 				PubSub: pubsubraw.NewPubSub(ipfsNodeB.PubSub(), ipfsNodeB.MockNode().PeerHost.ID(), logger, nil),
 				Logger: logger,

--- a/orbitdb.go
+++ b/orbitdb.go
@@ -95,7 +95,7 @@ type (
 	GroupsSigPubKeyMap = sync.Map
 )
 
-type BertyOrbitDB struct {
+type WeshOrbitDB struct {
 	baseorbitdb.BaseOrbitDB
 	keyStore         *BertySignedKeyStore
 	messageKeystore  *cryptoutil.MessageKeystore
@@ -111,7 +111,7 @@ type BertyOrbitDB struct {
 	groupsSigPubKey *GroupsSigPubKeyMap // map[string]crypto.PubKey
 }
 
-func (s *BertyOrbitDB) registerGroupPrivateKey(g *protocoltypes.Group) error {
+func (s *WeshOrbitDB) registerGroupPrivateKey(g *protocoltypes.Group) error {
 	groupID := g.GroupIDAsString()
 
 	gSigSK, err := g.GetSigningPrivKey()
@@ -130,7 +130,7 @@ func (s *BertyOrbitDB) registerGroupPrivateKey(g *protocoltypes.Group) error {
 	return nil
 }
 
-func (s *BertyOrbitDB) registerGroupSigningPubKey(g *protocoltypes.Group) error {
+func (s *WeshOrbitDB) registerGroupSigningPubKey(g *protocoltypes.Group) error {
 	groupID := g.GroupIDAsString()
 
 	var gSigPK crypto.PubKey
@@ -152,7 +152,7 @@ func (s *BertyOrbitDB) registerGroupSigningPubKey(g *protocoltypes.Group) error 
 	return nil
 }
 
-func NewBertyOrbitDB(ctx context.Context, ipfs coreapi.CoreAPI, options *NewOrbitDBOptions) (*BertyOrbitDB, error) {
+func NewWeshOrbitDB(ctx context.Context, ipfs coreapi.CoreAPI, options *NewOrbitDBOptions) (*WeshOrbitDB, error) {
 	var err error
 
 	if options == nil {
@@ -182,7 +182,7 @@ func NewBertyOrbitDB(ctx context.Context, ipfs coreapi.CoreAPI, options *NewOrbi
 		return nil, errcode.TODO.Wrap(err)
 	}
 
-	bertyDB := &BertyOrbitDB{
+	bertyDB := &WeshOrbitDB{
 		ctx:              ctx,
 		messageMarshaler: mm,
 		BaseOrbitDB:      orbitDB,
@@ -205,7 +205,7 @@ func NewBertyOrbitDB(ctx context.Context, ipfs coreapi.CoreAPI, options *NewOrbi
 	return bertyDB, nil
 }
 
-func (s *BertyOrbitDB) openAccountGroup(ctx context.Context, options *orbitdb.CreateDBOptions, ipfsCoreAPI ipfsutil.ExtendedCoreAPI) (*GroupContext, error) {
+func (s *WeshOrbitDB) openAccountGroup(ctx context.Context, options *orbitdb.CreateDBOptions, ipfsCoreAPI ipfsutil.ExtendedCoreAPI) (*GroupContext, error) {
 	l := s.Logger()
 
 	if options == nil {
@@ -255,7 +255,7 @@ func (s *BertyOrbitDB) openAccountGroup(ctx context.Context, options *orbitdb.Cr
 	return gc, nil
 }
 
-func (s *BertyOrbitDB) setHeadsForGroup(ctx context.Context, g *protocoltypes.Group, metaHeads, messageHeads []cid.Cid) error {
+func (s *WeshOrbitDB) setHeadsForGroup(ctx context.Context, g *protocoltypes.Group, metaHeads, messageHeads []cid.Cid) error {
 	id := g.GroupIDAsString()
 
 	var (
@@ -336,7 +336,7 @@ func (s *BertyOrbitDB) setHeadsForGroup(ctx context.Context, g *protocoltypes.Gr
 	return nil
 }
 
-func (s *BertyOrbitDB) loadHeads(ctx context.Context, store iface.Store, heads []cid.Cid) (err error) {
+func (s *WeshOrbitDB) loadHeads(ctx context.Context, store iface.Store, heads []cid.Cid) (err error) {
 	sub, err := store.EventBus().Subscribe(new(stores.EventReplicated))
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to EventReplicated")
@@ -381,7 +381,7 @@ func (s *BertyOrbitDB) loadHeads(ctx context.Context, store iface.Store, heads [
 	return nil
 }
 
-func (s *BertyOrbitDB) OpenGroup(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (*GroupContext, error) {
+func (s *WeshOrbitDB) OpenGroup(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (*GroupContext, error) {
 	if s.deviceKeystore == nil || s.messageKeystore == nil {
 		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("db open in naive mode"))
 	}
@@ -457,7 +457,7 @@ func (s *BertyOrbitDB) OpenGroup(ctx context.Context, g *protocoltypes.Group, op
 	return gc, nil
 }
 
-func (s *BertyOrbitDB) OpenGroupReplication(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (iface.Store, iface.Store, error) {
+func (s *WeshOrbitDB) OpenGroupReplication(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (iface.Store, iface.Store, error) {
 	if g == nil || len(g.PublicKey) == 0 {
 		return nil, nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("missing group or group pubkey"))
 	}
@@ -492,7 +492,7 @@ func (s *BertyOrbitDB) OpenGroupReplication(ctx context.Context, g *protocoltype
 	return metadataStore, messageStore, nil
 }
 
-func (s *BertyOrbitDB) getGroupContext(id string) (*GroupContext, error) {
+func (s *WeshOrbitDB) getGroupContext(id string) (*GroupContext, error) {
 	g, ok := s.groupContexts.Load(id)
 	if !ok {
 		return nil, errcode.ErrMissingMapKey
@@ -514,7 +514,7 @@ func (s *BertyOrbitDB) getGroupContext(id string) (*GroupContext, error) {
 
 // SetGroupSigPubKey registers a new group signature pubkey, mainly used to
 // replicate a store data without needing to access to its content
-func (s *BertyOrbitDB) SetGroupSigPubKey(groupID string, pubKey crypto.PubKey) error {
+func (s *WeshOrbitDB) SetGroupSigPubKey(groupID string, pubKey crypto.PubKey) error {
 	if pubKey == nil {
 		return errcode.ErrInvalidInput
 	}
@@ -524,7 +524,7 @@ func (s *BertyOrbitDB) SetGroupSigPubKey(groupID string, pubKey crypto.PubKey) e
 	return nil
 }
 
-func (s *BertyOrbitDB) storeForGroup(ctx context.Context, o iface.BaseOrbitDB, g *protocoltypes.Group, options *orbitdb.CreateDBOptions, storeType string, groupOpenMode GroupOpenMode) (iface.Store, error) {
+func (s *WeshOrbitDB) storeForGroup(ctx context.Context, o iface.BaseOrbitDB, g *protocoltypes.Group, options *orbitdb.CreateDBOptions, storeType string, groupOpenMode GroupOpenMode) (iface.Store, error) {
 	l := s.Logger()
 
 	options, err := DefaultOrbitDBOptions(g, options, s.keyStore, storeType, groupOpenMode)
@@ -579,7 +579,7 @@ func (s *BertyOrbitDB) storeForGroup(ctx context.Context, o iface.BaseOrbitDB, g
 	return store, nil
 }
 
-func (s *BertyOrbitDB) groupMetadataStore(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (*MetadataStore, error) {
+func (s *WeshOrbitDB) groupMetadataStore(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (*MetadataStore, error) {
 	if options == nil {
 		options = &orbitdb.CreateDBOptions{}
 	}
@@ -606,7 +606,7 @@ func (s *BertyOrbitDB) groupMetadataStore(ctx context.Context, g *protocoltypes.
 	return sStore, nil
 }
 
-func (s *BertyOrbitDB) groupMessageStore(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (*MessageStore, error) {
+func (s *WeshOrbitDB) groupMessageStore(ctx context.Context, g *protocoltypes.Group, options *orbitdb.CreateDBOptions) (*MessageStore, error) {
 	if options == nil {
 		options = &orbitdb.CreateDBOptions{}
 	}
@@ -629,7 +629,7 @@ func (s *BertyOrbitDB) groupMessageStore(ctx context.Context, g *protocoltypes.G
 	return mStore, nil
 }
 
-func (s *BertyOrbitDB) getGroupFromOptions(options *iface.NewStoreOptions) (*protocoltypes.Group, error) {
+func (s *WeshOrbitDB) getGroupFromOptions(options *iface.NewStoreOptions) (*protocoltypes.Group, error) {
 	groupIDs, err := options.AccessController.GetAuthorizedByRole(identityGroupIDKey)
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
@@ -652,12 +652,12 @@ func (s *BertyOrbitDB) getGroupFromOptions(options *iface.NewStoreOptions) (*pro
 	return typed, nil
 }
 
-func (s *BertyOrbitDB) IsGroupLoaded(groupID string) bool {
+func (s *WeshOrbitDB) IsGroupLoaded(groupID string) bool {
 	gc, ok := s.groups.Load(groupID)
 
 	return ok && gc != nil
 }
 
-func (s *BertyOrbitDB) GetDevicePKForPeerID(id peer.ID) (pdg *PeerDeviceGroup, ok bool) {
+func (s *WeshOrbitDB) GetDevicePKForPeerID(id peer.ID) (pdg *PeerDeviceGroup, ok bool) {
 	return s.messageMarshaler.GetDevicePKForPeerID(id)
 }

--- a/orbitdb_many_adds_berty_test.go
+++ b/orbitdb_many_adds_berty_test.go
@@ -42,7 +42,7 @@ func testAddBerty(ctx context.Context, t *testing.T, node ipfsutil.CoreAPIMock, 
 	baseDS = sync_ds.MutexWrap(baseDS)
 	defer testutil.Close(t, baseDS)
 
-	odb, err := NewBertyOrbitDB(ctx, api, &NewOrbitDBOptions{
+	odb, err := NewWeshOrbitDB(ctx, api, &NewOrbitDBOptions{
 		Datastore: baseDS,
 	})
 	require.NoError(t, err)

--- a/service.go
+++ b/service.go
@@ -56,7 +56,7 @@ type service struct {
 	ctxCancel              context.CancelFunc
 	logger                 *zap.Logger
 	ipfsCoreAPI            ipfsutil.ExtendedCoreAPI
-	odb                    *BertyOrbitDB
+	odb                    *WeshOrbitDB
 	accountGroup           *GroupContext
 	deviceKeystore         cryptoutil.DeviceKeystore
 	openedGroups           map[string]*GroupContext
@@ -93,7 +93,7 @@ type Opts struct {
 	GroupDatastore   *cryptoutil.GroupDatastore
 	AccountCache     ds.Batching
 	MessageKeystore  *cryptoutil.MessageKeystore
-	OrbitDB          *BertyOrbitDB
+	OrbitDB          *WeshOrbitDB
 	TinderService    *tinder.Service
 	Host             host.Host
 	PubSub           *pubsub.PubSub
@@ -207,7 +207,7 @@ func (opts *Opts) applyDefaults(ctx context.Context) error {
 			odbOpts.DirectChannelFactory = directchannel.InitDirectChannelFactory(opts.Logger, opts.Host)
 		}
 
-		odb, err := NewBertyOrbitDB(ctx, opts.IpfsCoreAPI, odbOpts)
+		odb, err := NewWeshOrbitDB(ctx, opts.IpfsCoreAPI, odbOpts)
 		if err != nil {
 			return err
 		}

--- a/store_message.go
+++ b/store_message.go
@@ -376,7 +376,7 @@ func messageStoreAddMessage(ctx context.Context, g *protocoltypes.Group, md *cry
 	return op, nil
 }
 
-func constructorFactoryGroupMessage(s *BertyOrbitDB, logger *zap.Logger) iface.StoreConstructor {
+func constructorFactoryGroupMessage(s *WeshOrbitDB, logger *zap.Logger) iface.StoreConstructor {
 	return func(ipfs coreapi.CoreAPI, identity *identityprovider.Identity, addr address.Address, options *iface.NewStoreOptions) (iface.Store, error) {
 		g, err := s.getGroupFromOptions(options)
 		if err != nil {

--- a/store_metadata.go
+++ b/store_metadata.go
@@ -987,7 +987,7 @@ type EventMetadataReceived struct {
 	Event     proto.Message
 }
 
-func constructorFactoryGroupMetadata(s *BertyOrbitDB, logger *zap.Logger) iface.StoreConstructor {
+func constructorFactoryGroupMetadata(s *WeshOrbitDB, logger *zap.Logger) iface.StoreConstructor {
 	return func(ipfs coreapi.CoreAPI, identity *identityprovider.Identity, addr address.Address, options *iface.NewStoreOptions) (iface.Store, error) {
 		g, err := s.getGroupFromOptions(options)
 		if err != nil {

--- a/testing.go
+++ b/testing.go
@@ -41,7 +41,7 @@ import (
 
 const InMemoryDir = ":memory:"
 
-func NewTestOrbitDB(ctx context.Context, t *testing.T, logger *zap.Logger, node ipfsutil.CoreAPIMock, baseDS datastore.Batching) *BertyOrbitDB {
+func NewTestOrbitDB(ctx context.Context, t *testing.T, logger *zap.Logger, node ipfsutil.CoreAPIMock, baseDS datastore.Batching) *WeshOrbitDB {
 	t.Helper()
 
 	api := node.API()
@@ -54,7 +54,7 @@ func NewTestOrbitDB(ctx context.Context, t *testing.T, logger *zap.Logger, node 
 
 	pubSub := pubsubraw.NewPubSub(node.PubSub(), selfKey.ID(), logger, nil)
 
-	odb, err := NewBertyOrbitDB(ctx, api, &NewOrbitDBOptions{
+	odb, err := NewWeshOrbitDB(ctx, api, &NewOrbitDBOptions{
 		Datastore: baseDS,
 		NewOrbitDBOptions: orbitdb.NewOrbitDBOptions{
 			Logger: logger,
@@ -68,7 +68,7 @@ func NewTestOrbitDB(ctx context.Context, t *testing.T, logger *zap.Logger, node 
 
 type mockedPeer struct {
 	CoreAPI ipfsutil.CoreAPIMock
-	DB      *BertyOrbitDB
+	DB      *WeshOrbitDB
 	GC      *GroupContext
 	MKS     *cryptoutil.MessageKeystore
 	DevKS   cryptoutil.DeviceKeystore
@@ -87,7 +87,7 @@ type TestingProtocol struct {
 	RootDatastore  datastore.Batching
 	DeviceKeystore cryptoutil.DeviceKeystore
 	IpfsCoreAPI    ipfsutil.ExtendedCoreAPI
-	OrbitDB        *BertyOrbitDB
+	OrbitDB        *WeshOrbitDB
 	GroupDatastore *cryptoutil.GroupDatastore
 }
 
@@ -97,7 +97,7 @@ type TestingOpts struct {
 	DiscoveryServer *tinder.MockDriverServer
 	DeviceKeystore  cryptoutil.DeviceKeystore
 	CoreAPIMock     ipfsutil.CoreAPIMock
-	OrbitDB         *BertyOrbitDB
+	OrbitDB         *WeshOrbitDB
 	ConnectFunc     ConnectTestingProtocolFunc
 	PushSK          *[32]byte
 }
@@ -137,7 +137,7 @@ func NewTestingProtocol(ctx context.Context, t testing.TB, opts *TestingOpts, ds
 
 		pubSub := pubsubraw.NewPubSub(node.PubSub(), node.MockNode().PeerHost.ID(), opts.Logger, nil)
 
-		odb, err = NewBertyOrbitDB(ctx, node.API(), &NewOrbitDBOptions{
+		odb, err = NewWeshOrbitDB(ctx, node.API(), &NewOrbitDBOptions{
 			NewOrbitDBOptions: orbitdb.NewOrbitDBOptions{
 				PubSub: pubSub,
 				Logger: opts.Logger,
@@ -385,7 +385,7 @@ func CreatePeersWithGroupTest(ctx context.Context, t testing.TB, pathBase string
 
 			mk, cleanupMessageKeystore := cryptoutil.NewInMemMessageKeystore(logger)
 
-			db, err := NewBertyOrbitDB(ctx, ca.API(), &NewOrbitDBOptions{
+			db, err := NewWeshOrbitDB(ctx, ca.API(), &NewOrbitDBOptions{
 				NewOrbitDBOptions: orbitdb.NewOrbitDBOptions{
 					Logger: logger,
 				},


### PR DESCRIPTION
As part of the separation of Wesh from Berty Messenger, rename the struct BertyOrbitDB to WeshOrbitDB.

When Berty Messenger uses the new version of weshnet, it will be necessary to do the same rename, for example [in the Manager struct](https://github.com/berty/berty/blob/7c0fdaff9a86d05107d43f9fcf15e1e7a886b8ef/go/internal/initutil/manager.go#L164).

