### PR TITLE
chore: remove testutil.Flappy filter in some tests

### DIFF
--- a/account_export_test.go
+++ b/account_export_test.go
@@ -134,9 +134,7 @@ func Test_service_exportAccountProofKey(t *testing.T) {
 	require.True(t, accountProofSK.Equals(sk))
 }
 
-func TestFlappyRestoreAccount(t *testing.T) {
-	testutil.FilterStability(t, testutil.Flappy)
-
+func TestRestoreAccount(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/store_message_test.go
+++ b/store_message_test.go
@@ -95,8 +95,6 @@ func Test_AddMessage_ListMessages_manually_supplying_secrets(t *testing.T) {
 	out, err = peers[1].GC.MessageStore().ListEvents(ctx, nil, nil, false)
 	require.NoError(t, err)
 
-	testutil.FilterStability(t, testutil.Flappy)
-
 	<-time.After(time.Second)
 
 	require.Equal(t, 1+entriesCount, countEntries(out))

--- a/store_metadata_test.go
+++ b/store_metadata_test.go
@@ -176,8 +176,8 @@ func ipfsAPIUsingMockNet(ctx context.Context, t *testing.T) ipfsutil.ExtendedCor
 	return node.API()
 }
 
-func TestFlappyMetadataRendezvousPointLifecycle(t *testing.T) {
-	testutil.FilterStabilityAndSpeed(t, testutil.Flappy, testutil.Fast)
+func TestMetadataRendezvousPointLifecycle(t *testing.T) {
+	testutil.FilterSpeed(t, testutil.Fast)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
After recent bug fixes, some flappy tests are now passing on the CI runner with `TEST_STABILITY=flappy go test -v -race -count=25` . In `Test_AddMessage_ListMessages_manually_supplying_secrets`, we remove the flappy filter at the end of the test. In `TestFlappyRestoreAccount` and `TestFlappyMetadataRendezvousPointLifecycle`, we remove the flappy filter and rename to remove "Flappy".

For now, we do not change the remaining flappy tests: `TestFlappyMultiDevices_Basic`, `TestRaceReactivateAccountGroup` and `TestRaceReactivateContactGroup`, and the tests in scenario_test.go .