### PR TITLE
fix: Rename persistant to persistent (spelling)

### DIFF
--- a/blackbox_test.go
+++ b/blackbox_test.go
@@ -74,8 +74,8 @@ func ExampleNewPersistentServiceClient_basic() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// create a temporary path to host data of our persistant service
-	path, err := os.MkdirTemp("", "weshnet-test-persistant")
+	// create a temporary path to host data of our persistent service
+	path, err := os.MkdirTemp("", "weshnet-test-persistent")
 	if err != nil {
 		panic(err)
 	}

--- a/service_client.go
+++ b/service_client.go
@@ -102,7 +102,7 @@ func NewPersistentServiceClient(path string) (ServiceClient, error) {
 		return nil, err
 	}
 
-	return &persistantServiceClient{
+	return &persistentServiceClient{
 		ServiceClient: cl,
 		ds:            ds,
 	}, nil
@@ -117,12 +117,12 @@ type serviceClient struct {
 	server  *grpc.Server
 }
 
-type persistantServiceClient struct {
+type persistentServiceClient struct {
 	ServiceClient
 	ds datastore.Batching
 }
 
-func (p *persistantServiceClient) Close() error {
+func (p *persistentServiceClient) Close() error {
 	err := p.ServiceClient.Close()
 
 	if dserr := p.ds.Close(); err == nil && dserr != nil {


### PR DESCRIPTION
This is a low-priority pull request to fix the spelling of "persistent". It is low priority because the fix is only for internal identifiers.
