### PR TITLE
fix: In processMessageLoop, process the message without a goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.7.0
 	golang.org/x/net v0.8.0
-	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.8.0
 	golang.org/x/tools v0.7.0
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
@@ -309,6 +308,7 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/oauth2 v0.1.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd // indirect


### PR DESCRIPTION
To avoid out-of-order processing, don't process messages with concurrent goroutines. We only need a goroutine to signal the next message without blocking. (And now we don't need a semaphore.)
