### PR TITLE
fix: In processMessageLoop, call muDeviceCaches.Unlock() before continue

### DIFF
--- a/store_message.go
+++ b/store_message.go
@@ -205,6 +205,7 @@ func (m *MessageStore) processMessageLoop(ctx context.Context) {
 				m.logger.Error("unable to process message", zap.Error(err))
 			}
 
+			m.muDeviceCaches.Unlock()
 			continue
 		}
 


### PR DESCRIPTION
PR #45 changed `processMessageLoop` to not use a goroutine. After an error, it does `continue`. But we need to unlock the mutex before `continue`, similar to [another place](https://github.com/jefft0/weshnet/blob/7bab7b718d03787da18dccd326d1efa2d4def1ba/store_message.go#L190) in the same function.

This PR fixes the bug of not syncing over 100 pending messages when the receiver starts.