### PR TITLE
chore: Don't run codeql workflow on forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,6 +35,8 @@ on:
 
 jobs:
   analyze:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Only run the job if github.repository_owner == 'berty' . This prevents running when a user syncs a fork.

