### PR TITLE
chore: Don't run workflow jobs on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   benchmark:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     if: github.event_name == 'DISABLED'
     name: Run benchmarks
     runs-on: ubuntu-latest

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -7,6 +7,8 @@ on:
 # from https://docs.buf.build/ci-cd/github-actions#buf-push
 jobs:
   buf-release:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   check:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1.5.1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   golangci-lint:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Golangci-lint
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +55,8 @@ jobs:
   #
   # we hope we can remove this job because all the tests are stable 100% of the time
   flappy-tests:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Flappy tests (Linux)
     runs-on: ubuntu-latest
     steps:
@@ -103,6 +107,8 @@ jobs:
         run: make go.flappy-tests
 
   go-tests-on-linux:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Stable tests (Linux)
     runs-on: ubuntu-latest
     steps:
@@ -167,6 +173,8 @@ jobs:
           fail_ci_if_error: false
 
   go-tests-on-windows:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Stable tests (Windows)
     runs-on: windows-latest
     steps:
@@ -211,6 +219,8 @@ jobs:
         run: go.exe test ./...  -buildmode=exe -timeout=600s -count=1
 
   go-tests-on-macos:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Stable tests (macOS)
     runs-on: macos-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   preview:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Release Note Preview
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -38,6 +38,8 @@ on:
       - "**/go.sum"
 jobs:
   gen-go-and-docs:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     if: github.event_name == 'DISABLED' # need to fix it by removing docker for generation
     name: Generate go protobuf and docs
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   semantic-release:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Semantic release
     runs-on: ubuntu-latest
     outputs:
@@ -50,6 +52,8 @@ jobs:
           echo "::set-output name=release-version::${{steps.semantic.outputs.release-version}}"
 
   post-semantic-release:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     needs: semantic-release
     #if: needs.semantic-release.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR #61 was successful to prevent running the codeql workflow jobs when syncing a fork. This pull request does the same for the other workflow jobs. Only run the job if github.repository_owner == 'berty' .
