### PR TITLE
chore: Fix PR #66 syntax. Don't run workflow jobs on forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,8 +22,7 @@ on:
 jobs:
   benchmark:
     # Check repository owner so that we don't run on a fork.
-    if: github.repository_owner == 'berty'
-    if: github.event_name == 'DISABLED'
+    if: github.repository_owner == 'berty' && github.event_name == 'DISABLED'
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -39,8 +39,7 @@ on:
 jobs:
   gen-go-and-docs:
     # Check repository owner so that we don't run on a fork.
-    if: github.repository_owner == 'berty'
-    if: github.event_name == 'DISABLED' # need to fix it by removing docker for generation
+    if: github.repository_owner == 'berty' && github.event_name == 'DISABLED' # need to fix it by removing docker for generation
     name: Generate go protobuf and docs
     runs-on: ubuntu-latest
     container: bertytech/buf:1


### PR DESCRIPTION
PR #66 was successful to prevent running the workflow jobs when syncing a fork, except where there are two `if` statements. These need to be combined into one `if` statement with `&&`.