### PR TITLE
In .tool-versions comments, remove version numbers and dates in comments

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,11 +1,15 @@
+# To see the date when a version was updated, use git blame:
+# https://github.com/berty/weshnet/blame/main/.tool-versions
+
 #-----
-# golang golang 1.19.7 is simply the most recent version available to date (03/30).
+# This is simply the most recent version available to date of the lowest 
+# major version of Go which is allowed by kubo.
 # There is no contraindication for updating it.
 #-----
 golang 1.19.7
 
 #-----
-# golangci-lint 1.51.2 is simply the most recent version available to date (07/22).
+# This is simply the most recent golangci-lint version available to date.
 #
 # @TODO(gfanton): check if we still have this issue
 # The current version of golangci-lint also has a problem displaying logs on
@@ -17,13 +21,13 @@ golang 1.19.7
 golangci-lint 1.51.2
 
 #-----
-# jq 1.6 is simply the most recent version available to date (07/22).
+# This is simply the most recent jq version available to date.
 # There is no contraindication for updating it.
 #-----
 jq 1.6
 
 #-----
-# buf 1.14.0 is simply the most recent version available to date (03/23).
+# This is simply the most recent buf version available to date.
 # There is no contraindication for updating it.
 #-----
 buf 1.15.1


### PR DESCRIPTION
Remove specific version numbers and dates in the comments because they get out of sync when we do global updates of actual version numbers. Put a comment at the top of the file explaining that the "as of" date can be seen in git blame.
