### PR TITLE
fix: event Infinity loop

### DIFF
--- a/api_event.go
+++ b/api_event.go
@@ -60,10 +60,6 @@ func (s *service) GroupMetadataList(req *protocoltypes.GroupMetadataList_Request
 		}
 		defer sub.Close()
 		newEvents = sub.Out()
-	} else {
-		noop := make(chan interface{})
-		newEvents = noop
-		defer close(noop)
 	}
 
 	// Subscribe to previous metadata events and stream them if requested
@@ -149,10 +145,6 @@ func (s *service) GroupMessageList(req *protocoltypes.GroupMessageList_Request, 
 		}
 		defer messageStoreSub.Close()
 		newEvents = messageStoreSub.Out()
-	} else {
-		noop := make(chan interface{})
-		newEvents = noop
-		defer close(noop)
 	}
 
 	// Subscribe to previous message events and stream them if requested


### PR DESCRIPTION
fix potential infinity loop caused by closed channel instead of keeping it at `nil`