### PR TITLE
chore: README: Update the buf doc link to berty-technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Wesh and walk you through some example applications and background of the Wesh p
 import "berty.tech/weshnet"
 ```
 
-Online API documentation is at https://buf.build/berty/weshnet .
+Online API documentation is at https://buf.build/berty-technologies/weshnet .
 
 ## Get the code
 


### PR DESCRIPTION
Similar to PR https://github.com/berty/www.wesh.network/pull/34 on the weshnet website, update links to the buf API docs to berty-technologies .
