### PR TITLE
fix: set repo path correctly

### DIFF
--- a/service.go
+++ b/service.go
@@ -181,7 +181,7 @@ func (opts *Opts) applyDefaults(ctx context.Context) error {
 			return err
 		}
 
-		mrepo := ipfs_mobile.NewRepoMobile("", repo)
+		mrepo := ipfs_mobile.NewRepoMobile(opts.DatastoreDir, repo)
 		mnode, err = ipfsutil.NewIPFSMobile(ctx, mrepo, &ipfsutil.MobileOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR sets the IPFS mobile repo path correctly when we create it. So we will be able to get this information in the struct later.

<!-- Thank you for your contribution! ❤️ -->
