### PR TITLE
fix: proximitytransport creation

### DIFF
--- a/pkg/proximitytransport/conn.go
+++ b/pkg/proximitytransport/conn.go
@@ -51,7 +51,7 @@ func newConn(ctx context.Context, t *proximityTransport, remoteMa ma.Multiaddr, 
 		return nil, fmt.Errorf("invalid network direction")
 	}
 
-	connScope, err := t.rcmgr.OpenConnection(netdir, false, remoteMa)
+	connScope, err := t.swarm.ResourceManager().OpenConnection(netdir, false, remoteMa)
 	if err != nil {
 		return nil, fmt.Errorf("resource manager blocked connection : %w", err)
 	}

--- a/pkg/proximitytransport/listener.go
+++ b/pkg/proximitytransport/listener.go
@@ -48,7 +48,7 @@ func newListener(ctx context.Context, localMa ma.Multiaddr, t *proximityTranspor
 	// Starts the native driver.
 	// If it failed, don't return a error because no other transport
 	// on the libp2p node will be created.
-	t.driver.Start(t.host.ID().String())
+	t.driver.Start(t.swarm.LocalPeer().String())
 
 	return listener
 }


### PR DESCRIPTION
When the proximity transport was created, it took a `host.Host` as argument. But since https://github.com/libp2p/go-libp2p/pull/2118, the host argument is not more provided causing a failure on proximitytransport.
Instead of getting the host, we get the swarm to work with.

Btw, I opened a libp2p PR to update the Transport option documentation: https://github.com/libp2p/go-libp2p/pull/3144