### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/rendezvous/rotation.go
+++ b/pkg/rendezvous/rotation.go
@@ -109,10 +109,7 @@ func (r *RotationInterval) rotate(old *Point, graceperiod time.Duration) *Point 
 	// register new point
 	r.registerPoint(newPoint)
 
-	cleanuptime := time.Until(newPoint.Deadline().Add(graceperiod))
-	if cleanuptime < 0 {
-		cleanuptime = 0
-	}
+	cleanuptime := max(time.Until(newPoint.Deadline().Add(graceperiod)), 0)
 	// cleanup after the grace period
 	time.AfterFunc(cleanuptime, func() {
 		r.muCache.Lock()


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.