### PR TITLE
feat: Support top level service options rdvp and relay nodes

### DIFF
--- a/pkg/outofstoremessage/service_outofstoremessage.go
+++ b/pkg/outofstoremessage/service_outofstoremessage.go
@@ -1,4 +1,4 @@
-package weshnet
+package outofstoremessage
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"berty.tech/weshnet/v2"
 	"berty.tech/weshnet/v2/pkg/errcode"
 	"berty.tech/weshnet/v2/pkg/grpcutil"
 	"berty.tech/weshnet/v2/pkg/outofstoremessagetypes"
@@ -89,7 +90,7 @@ func (c *oosmClient) Close() error {
 }
 
 func newClientFromService(ctx context.Context, s *grpc.Server, svc OOSMService, opts ...grpc.DialOption) (OOSMServiceClient, error) {
-	bl := grpcutil.NewBufListener(ClientBufferSize)
+	bl := grpcutil.NewBufListener(weshnet.ClientBufferSize)
 	cc, err := bl.NewClientConn(ctx, opts...)
 	if err != nil {
 		return nil, err
@@ -127,8 +128,8 @@ func (s *oosmService) Close() error {
 	return nil
 }
 
-func (s *oosmService) Status() (Status, error) {
-	return Status{}, nil
+func (s *oosmService) Status() (weshnet.Status, error) {
+	return weshnet.Status{}, nil
 }
 
 func (s *oosmService) IpfsCoreAPI() coreiface.CoreAPI {


### PR DESCRIPTION
The `Opts` for the general-purpose `NewServiceClient` now has `P2PStaticRelays` and `P2PRdvpMaddrs`. We want users of the more specific helper functions `NewInMemoryServiceClient` and `NewPersistentServiceClient` to be able to use them.

* Move the options for `OOSMOption` and related functions to the sub package `pkg/outofstoremessage` . This frees up the namespace `weshnet`
* Add `ServiceOption` and related "With" functions like `WithP2PStaticRelays`
* In `NewInMemoryServiceClient` and `NewPersistentServiceClient`, copy the supplied options to `Opts`