### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/api_event.go
+++ b/api_event.go
@@ -49,9 +49,9 @@ func (s *service) GroupMetadataList(req *protocoltypes.GroupMetadataList_Request
 	}
 
 	// Subscribe to new metadata events if requested
-	var newEvents <-chan interface{}
+	var newEvents <-chan any
 	if req.UntilId == nil && !req.UntilNow {
-		sub, err := cg.MetadataStore().EventBus().Subscribe([]interface{}{
+		sub, err := cg.MetadataStore().EventBus().Subscribe([]any{
 			// new(stores.EventReplicated),
 			new(*protocoltypes.GroupMetadataEvent),
 		}, eventbus.Name("weshnet/api/group-metadata-list"), eventbus.BufSize(32))
@@ -99,7 +99,7 @@ func (s *service) GroupMetadataList(req *protocoltypes.GroupMetadataList_Request
 
 	// Subscribe to new metadata events and stream them if requested
 	for {
-		var event interface{}
+		var event any
 		select {
 		case <-ctx.Done():
 			return nil
@@ -137,9 +137,9 @@ func (s *service) GroupMessageList(req *protocoltypes.GroupMessageList_Request, 
 	}
 
 	// Subscribe to new message events if requested
-	var newEvents <-chan interface{}
+	var newEvents <-chan any
 	if req.UntilId == nil && !req.UntilNow {
-		messageStoreSub, err := cg.MessageStore().EventBus().Subscribe([]interface{}{
+		messageStoreSub, err := cg.MessageStore().EventBus().Subscribe([]any{
 			new(*protocoltypes.GroupMessageEvent),
 		}, eventbus.Name("weshnet/api/group-message-list"))
 		if err != nil {
@@ -186,7 +186,7 @@ func (s *service) GroupMessageList(req *protocoltypes.GroupMessageList_Request, 
 
 	// Subscribe to new message events and stream them if requested
 	for {
-		var event interface{}
+		var event any
 		select {
 		case <-ctx.Done():
 			return nil

--- a/contact_request_manager.go
+++ b/contact_request_manager.go
@@ -145,7 +145,7 @@ func (c *contactRequestsManager) metadataWatcher(ctx context.Context) {
 
 	defer sub.Close()
 	for {
-		var evt interface{}
+		var evt any
 		select {
 		case evt = <-sub.Out():
 		case <-ctx.Done():

--- a/group_context.go
+++ b/group_context.go
@@ -124,7 +124,7 @@ func (gc *GroupContext) ActivateGroupContext(contactPK crypto.PubKey) (err error
 			defer sub.Close()
 
 			for {
-				var evt interface{}
+				var evt any
 				select {
 				case <-ctx.Done():
 					return
@@ -339,7 +339,7 @@ func (gc *GroupContext) TagGroupContextPeers(ipfsCoreAPI ipfsutil.ExtendedCoreAP
 		defer chSub2.Close()
 
 		for {
-			var e interface{}
+			var e any
 
 			select {
 			case e = <-chSub1.Out():

--- a/internal/queue/priority.go
+++ b/internal/queue/priority.go
@@ -81,12 +81,12 @@ func (pq *PriorityQueue[T]) Swap(i, j int) {
 	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
 }
 
-func (pq *PriorityQueue[T]) Push(x interface{}) {
+func (pq *PriorityQueue[T]) Push(x any) {
 	pq.items = append(pq.items, x.(T))
 	pq.metrics.ItemQueued(pq.name, x.(T))
 }
 
-func (pq *PriorityQueue[T]) Pop() (item interface{}) {
+func (pq *PriorityQueue[T]) Pop() (item any) {
 	var null T
 	if n := len(pq.items); n > 0 {
 		item = pq.items[n-1]

--- a/orbitdb_utils_test.go
+++ b/orbitdb_utils_test.go
@@ -81,7 +81,7 @@ func waitForBertyEventType(ctx context.Context, t *testing.T, ms *MetadataStore,
 	defer sub.Close()
 
 	for {
-		var e interface{}
+		var e any
 
 		select {
 		case e = <-sub.Out():

--- a/pkg/ipfsutil/lifecycle.go
+++ b/pkg/ipfsutil/lifecycle.go
@@ -151,7 +151,7 @@ func (cl *ConnLifecycle) dropUnavailableConn() {
 }
 
 func (cl *ConnLifecycle) monitorPeerOfInterest(ctx context.Context) error {
-	sub, err := cl.h.EventBus().Subscribe([]interface{}{
+	sub, err := cl.h.EventBus().Subscribe([]any{
 		new(EvtPeerTag),
 	}, eventbus.Name("weshnet/lifecycle/monitor-peer-of-interest"))
 	if err != nil {
@@ -169,7 +169,7 @@ func (cl *ConnLifecycle) monitorPeerOfInterest(ctx context.Context) error {
 	go func() {
 		defer sub.Close()
 		for {
-			var e interface{}
+			var e any
 			select {
 			case e = <-sub.Out():
 			case <-ctx.Done():

--- a/pkg/ipfsutil/repo.go
+++ b/pkg/ipfsutil/repo.go
@@ -173,25 +173,25 @@ func upgradeToPersistentConfig(cfg *ipfs_cfg.Config) (*ipfs_cfg.Config, error) {
 		StorageGCWatermark: 90, // 90%
 		GCPeriod:           "1h",
 		BloomFilterSize:    0,
-		Spec: map[string]interface{}{
+		Spec: map[string]any{
 			"type": "mount",
-			"mounts": []interface{}{
-				map[string]interface{}{
+			"mounts": []any{
+				map[string]any{
 					"mountpoint": "/blocks",
 					"type":       "measure",
 					"prefix":     "flatfs.datastore",
-					"child": map[string]interface{}{
+					"child": map[string]any{
 						"type":      "flatfs",
 						"path":      "blocks",
 						"sync":      true,
 						"shardFunc": "/repo/flatfs/shard/v1/next-to-last/2",
 					},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"mountpoint": "/",
 					"type":       "measure",
 					"prefix":     "leveldb.datastore",
-					"child": map[string]interface{}{
+					"child": map[string]any{
 						"type":        "levelds",
 						"path":        "datastore",
 						"compression": "none",

--- a/pkg/logutil/private_field.go
+++ b/pkg/logutil/private_field.go
@@ -64,7 +64,7 @@ func (p *PrivateField) PrivateStrings(key string, values []string) zap.Field {
 	return zap.Strings(key, values)
 }
 
-func (p *PrivateField) PrivateAny(key string, value interface{}) zap.Field {
+func (p *PrivateField) PrivateAny(key string, value any) zap.Field {
 	if p.Enabled {
 		return zap.String(key, p.hash(fmt.Sprintf("%+v", value)))
 	}
@@ -104,7 +104,7 @@ func PrivateStringer(key string, value fmt.Stringer) zap.Field {
 	return g.PrivateStringer(key, value)
 }
 
-func PrivateAny(key string, value interface{}) zap.Field {
+func PrivateAny(key string, value any) zap.Field {
 	mu.RLock()
 	g := global
 	mu.RUnlock()

--- a/pkg/protoio/io.go
+++ b/pkg/protoio/io.go
@@ -56,7 +56,7 @@ type marshaler interface {
 	MarshalTo(data []byte) (n int, err error)
 }
 
-func getSize(v interface{}) (int, bool) {
+func getSize(v any) (int, bool) {
 	if sz, ok := v.(interface {
 		Size() (n int)
 	}); ok {

--- a/pkg/testutil/logging.go
+++ b/pkg/testutil/logging.go
@@ -64,7 +64,7 @@ func LoggerWithRing(t testing.TB) (*zap.Logger, *zapring.Core, func()) {
 	return loggerInstance, loggerRing, loggerCleanup
 }
 
-func LogTree(t *testing.T, log string, indent int, title bool, args ...interface{}) {
+func LogTree(t *testing.T, log string, indent int, title bool, args ...any) {
 	t.Helper()
 	if os.Getenv("SHOW_LOG_TREES") != "1" {
 		return

--- a/pkg/tinder/driver_localdiscovery.go
+++ b/pkg/tinder/driver_localdiscovery.go
@@ -418,7 +418,7 @@ func (ld *LocalDiscovery) handleConnection(ctx context.Context, p peer.ID) {
 }
 
 func (ld *LocalDiscovery) monitorConnection(ctx context.Context) error {
-	sub, err := ld.h.EventBus().Subscribe([]interface{}{
+	sub, err := ld.h.EventBus().Subscribe([]any{
 		new(event.EvtPeerConnectednessChanged),
 		new(event.EvtPeerProtocolsUpdated),
 	}, eventbus.Name("weshnet/tinder/monitor-connection"))
@@ -436,7 +436,7 @@ func (ld *LocalDiscovery) monitorConnection(ctx context.Context) error {
 	go func() {
 		defer sub.Close()
 		for {
-			var e interface{}
+			var e any
 			select {
 			case e = <-sub.Out():
 			case <-ctx.Done():

--- a/pkg/tinder/driver_mock.go
+++ b/pkg/tinder/driver_mock.go
@@ -214,7 +214,7 @@ const (
 func MockBufferSize(size int) discovery.Option {
 	return func(opts *discovery.Options) error {
 		if opts.Other == nil {
-			opts.Other = make(map[interface{}]interface{})
+			opts.Other = make(map[any]any)
 		}
 
 		opts.Other[optionSubscribeBufferSize] = size

--- a/pkg/tyber/format.go
+++ b/pkg/tyber/format.go
@@ -15,7 +15,7 @@ type Detail struct {
 	Description string `json:"description"`
 }
 
-func safeJSONMarshal(v interface{}) string {
+func safeJSONMarshal(v any) string {
 	bs, err := json.MarshalIndent(v, "", "    ")
 	if err != nil {
 		return fmt.Sprintf(`"%s"`, err.Error())
@@ -23,11 +23,11 @@ func safeJSONMarshal(v interface{}) string {
 	return string(bs)
 }
 
-func JSONDetail(name string, val interface{}) Detail {
+func JSONDetail(name string, val any) Detail {
 	return Detail{Name: name, Description: safeJSONMarshal(val)}
 }
 
-func WithJSONDetail(name string, val interface{}) StepMutator {
+func WithJSONDetail(name string, val any) StepMutator {
 	return func(s Step) Step {
 		s.Details = append(s.Details, JSONDetail(name, val))
 		return s

--- a/service.go
+++ b/service.go
@@ -498,7 +498,7 @@ func (s *service) startGroupDeviceMonitor() {
 		defer subPeer.Close()
 
 		for {
-			var evt interface{}
+			var evt any
 
 			select {
 			case evt = <-subHead.Out():

--- a/store_message.go
+++ b/store_message.go
@@ -437,7 +437,7 @@ func constructorFactoryGroupMessage(s *WeshOrbitDB, logger *zap.Logger) iface.St
 			return store, nil
 		}
 
-		chSub, err := store.EventBus().Subscribe([]interface{}{
+		chSub, err := store.EventBus().Subscribe([]any{
 			new(stores.EventWrite),
 			new(stores.EventReplicated),
 		}, eventbus.Name("weshnet/store-message"), eventbus.BufSize(128))
@@ -448,7 +448,7 @@ func constructorFactoryGroupMessage(s *WeshOrbitDB, logger *zap.Logger) iface.St
 		go func(ctx context.Context) {
 			defer chSub.Close()
 			for {
-				var e interface{}
+				var e any
 				select {
 				case e = <-chSub.Out():
 				case <-ctx.Done():

--- a/store_message_test.go
+++ b/store_message_test.go
@@ -110,7 +110,7 @@ func Test_AddMessage_ListMessages_manually_supplying_secrets(t *testing.T) {
 
 func bufferCount(buffer *ring.Ring) int {
 	count := 0
-	buffer.Do(func(f interface{}) {
+	buffer.Do(func(f any) {
 		if _, ok := f.(ipfslog.Entry); ok {
 			count++
 		}

--- a/store_metadata.go
+++ b/store_metadata.go
@@ -937,7 +937,7 @@ func constructorFactoryGroupMetadata(s *WeshOrbitDB, logger *zap.Logger) iface.S
 			return store, nil
 		}
 
-		chSub, err := store.eventBus.Subscribe([]interface{}{
+		chSub, err := store.eventBus.Subscribe([]any{
 			new(stores.EventWrite),
 			new(stores.EventReplicated),
 		}, eventbus.BufSize(128))
@@ -953,7 +953,7 @@ func constructorFactoryGroupMetadata(s *WeshOrbitDB, logger *zap.Logger) iface.S
 			defer chSub.Close()
 
 			for {
-				var e interface{}
+				var e any
 				select {
 				case e = <-chSub.Out():
 				case <-ctx.Done():

--- a/store_metadata_index.go
+++ b/store_metadata_index.go
@@ -45,7 +45,7 @@ type metadataStoreIndex struct {
 }
 
 //nolint:revive
-func (m *metadataStoreIndex) Get(key string) interface{} {
+func (m *metadataStoreIndex) Get(key string) any {
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! ❤️ -->


This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.