### PR TITLE
chore: generate protobuf after go update

### DIFF
--- a/tool/docker-protoc/Dockerfile
+++ b/tool/docker-protoc/Dockerfile
@@ -1,7 +1,7 @@
 FROM    moul/protoc-gen-gotemplate:latest as pgg
 
 # build image
-FROM    golang:1.22-alpine as builder
+FROM    golang:1.26-alpine as builder
 # install deps
 RUN     apk --no-cache add make git go rsync libc-dev openssh docker npm bash curl
 # ensure we use bash for all RUN commands
@@ -26,7 +26,7 @@ RUN     asdf plugin add buf && asdf install buf && \
         cp $(asdf which buf) /go/bin/buf
 
 # runtime
-FROM    golang:1.22-alpine
+FROM    golang:1.26-alpine
 RUN     apk --no-cache add git openssh make protobuf gcc libc-dev nodejs npm yarn sudo perl-utils tar sed grep \
  &&     mkdir -p /.cache/go-build \
  &&     chmod -R 777 /.cache \

--- a/tool/docker-protoc/Makefile
+++ b/tool/docker-protoc/Makefile
@@ -1,5 +1,5 @@
 IMAGE ?=	bertytech/buf
-VERSION ?=	5
+VERSION ?=	6
 
 build:
 	cd ../../ && docker build -f ./tool/docker-protoc/Dockerfile -t $(IMAGE):$(VERSION) -t $(IMAGE):latest .


### PR DESCRIPTION
After updating golang to v1.26.4, we have to regenarate the protofiles with this go version.